### PR TITLE
01_scrape: Fix: Do not rely on existence of parent id

### DIFF
--- a/01_scrape/index.js
+++ b/01_scrape/index.js
@@ -216,15 +216,14 @@ class PageHandler {
     } else if (this.pageUrl === `${this.parent.origin}challenges`) {
       const chals = await page.evaluate(() => {
         return Array.from(document.querySelectorAll(
-            '.challenge-button')).map((e) => e.parentElement.id);
+            '.challenge-button')).map((e) => e.value);
       });
 
       for (const chal of chals) {
         // Challenge Tab
         this.browseCompleted = new HeartBeat();
         await page.evaluate((chal) => {
-          document.getElementById(chal)
-              .querySelector('.challenge-button')
+          document.querySelector(`.challenge-button[value="${chal}"]`)
               .click();
         }, chal);
         await this.browseCompleted.wait();


### PR DESCRIPTION
# Problem
ctfd2pages works fine on https://ctf2022.maplebacon.org/challenges, because the parent of `.challenge-button` has an unique id.

```html
<div id="1093826663" class="col-md-3 d-inline-block">
  <button class="[...] challenge-button [...]" value="7">
    [...]
  </button>
</div>
```

I tried to archive the CTF of my team (https://ctf.kitctf.me/challenges) and it failed, because our HTML has this structure.

```html
<div class="col-sm-6 col-md-4 col-lg-3">
  <button class="challenge-button [...]" value="9">
    [...]
  </button>
</div>
```

I know that CTFd should in theory always add this parent id (https://github.com/CTFd/CTFd/blob/3c299095cb501a30a05e1e7b96c582f4724cedf2/CTFd/themes/core/assets/js/pages/challenges.js#L320) but I _think_ that our custom theme interfered with this in some way.

# "Solution"
Try to match the `value=id` of `.challenge-button` which is (in theory) also always added (https://github.com/CTFd/CTFd/blob/3c299095cb501a30a05e1e7b96c582f4724cedf2/CTFd/themes/core/assets/js/pages/challenges.js#L325-L334)

Feel free to close/ignore this PR if this is not a change you want to do.