### PR TITLE
lib.sh: Fix stage 4 failing on user-mode CTFd instances

### DIFF
--- a/lib.sh
+++ b/lib.sh
@@ -18,6 +18,7 @@ do_stage() {
   verify_env
 
   set -ex
+  shopt -s nullglob
   (cd "$PAGES_REPO" && source "$DIR"/stage.sh)
 
   git -C "$PAGES_REPO" add -A


### PR DESCRIPTION
On user-mode CTFd instances, the glob for team pages in `04_fix_pagination/stage.sh` doesn't match any files and thus doesn't expand, causing `git mv` to fail on a non-existent file.  
The same issue is present with the `sed` glob later in the script.

Enabling nullglob fixes this by having the glob expand to a null string when no files match.