### PR TITLE
README.md: Add GPNCTF21

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ A ~~picture~~ live site is worth a thousand words:
   [2022](https://2022.uiuc.tf/), [2023](https://2023.uiuc.tf/)
 - MapleCTF [2022](https://ctf2022.maplebacon.org/)
 - SekaiCTF [2022](https://2022.ctf.sekai.team/)
-- KITCTFCTF [2022](https://2022.ctf.kitctf.de/)
+- KITCTFCTF [2022](https://2022.ctf.kitctf.de/) GPNCTF21 [2023](https://gpn21.ctf.kitctf.de/)
 - (Feel free to send us a PR and add yours here)
 
 ## Usage


### PR DESCRIPTION
This adds GPNCTF21 that was held in 2023 by KITCTF.
Note, the website is currently down until the right CNAME has been set.