### PR TITLE
README.md: Add CSCTF24

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ A ~~picture~~ live site is worth a thousand words:
 - MapleCTF [2022](https://ctf2022.maplebacon.org/)
 - SekaiCTF [2022](https://2022.ctf.sekai.team/)
 - KITCTFCTF [2022](https://2022.ctf.kitctf.de/) GPNCTF21 [2023](https://gpn21.ctf.kitctf.de/)
+- CSCTF [2024](https://2024.csc.tf/)
 - (Feel free to send us a PR and add yours here)
 
 ## Usage


### PR DESCRIPTION
Thank you for this amazing tool! This PR adds CSCTF'24, held on Aug 30, 2024.
Note: When using CTFd v3.7.3, I did run into a few issues, which might require some changes to the code.

1) When running stage 5, to fix the 404 pages, it fails because it cannot find the text "Sorry about that". This is because it has been changed to "404 Not found" in a [recent commit](https://github.com/CTFd/CTFd/commit/162bca6649d1cd17d6c4fb930010e53b183cd46d#diff-01937da08cc1316ff425fe3de122dac13d54008c816096b5d61642cc51a135c1).
2) The way the scoreboard is fetched seems to have been updated, because of the new scoreboard brackets feature introduced in v3.7.0, which broke fetching the list of teams on my end. I ended up adding it directly to the HTML for https://2024.csc.tf/scoreboard, but this might be worth looking into.